### PR TITLE
Fixing a typo ('outgoing instead of 'ougoing')

### DIFF
--- a/JAHJRTC/JAHJRTC.m
+++ b/JAHJRTC/JAHJRTC.m
@@ -125,7 +125,7 @@
 }
 
 + (NSString*)outgoingSDPOfferForSession:(NSDictionary*)session {
-    return [JAHConvertSDP SDPForSession:session options:@{@"role": @"initiator", @"direction": @"ougoing"}];
+    return [JAHConvertSDP SDPForSession:session options:@{@"role": @"initiator", @"direction": @"outgoing"}];
 }
 
 + (NSString*)incomingSDPAnswerForSession:(NSDictionary*)session {


### PR DESCRIPTION
Fixing a typo ('outgoing instead of 'ougoing') in +outgoingSDPOfferForSession: method's use of [JAHConvertSDP SDPForSession:options:].
